### PR TITLE
Introduced cache for Github auth checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ The file has to contain the following property:
 github.api.url=https://github.example.com/api/v3 #note: no trailing slash!!!
 ```
 
+You can optionally provide the property `github.principal.cache.ttl` and set it
+to a java.time.Duration string to configure how long a given Github access
+token will be cached for. The default duration is 1 minute and is a tradeoff of
+how quickly access can be revoked and how quickly a Github user's rate limit
+will be reached for the Github User API.
+
 #### 5. Restart Nexus
 Restart your Nexus instance to let it pick up your changes.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Within the file you can configure the following properties:
 
 |Property        |Description                              |Default|
 |---             |---                                      |---    |
-|`github.api.url`|URL of the Github API to operate against. Default is Github Public, you will only need this if you use Github Enterprise.|`https://github.example.com/api/v3` |
+|`github.api.url`|URL of the Github API to operate against.|*none* |
 |`github.principal.cache.ttl`|[Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) for how long a given Access will be cached for. This is a tradeoff of how quickly access can be revoked and how quickly a Github user's rate limit will be reached for the Github User API. Note: Github Enterprise does not have a rate limit!|`PT1M` (1 Minute)|
 
 This is what an example file would look like:

--- a/README.md
+++ b/README.md
@@ -43,20 +43,21 @@ Please replace _[PLUGIN_VERSION]_ by the current plugin version.
 mvn\:com.larscheidschmitzhermes/nexus3-github-oauth-plugin/[PLUGIN_VERSION] = 200
 ```
 
-#### 4. Create githuboauth.properties
-Create a `$install-dir/etc/githuboauth.properties`
+#### 4. Create configuration within `githuboauth.properties` file
+Create `$install-dir/etc/githuboauth.properties`
 
-The file has to contain the following property:
+Within the file you can configure the following properties:
 
+|Property        |Description                              |Default|
+|---             |---                                      |---    |
+|`github.api.url`|URL of the Github API to operate against. Default is Github Public, you will only need this if you use Github Enterprise.|`https://github.example.com/api/v3` |
+|`github.principal.cache.ttl`|[Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) for how long a given Access will be cached for. This is a tradeoff of how quickly access can be revoked and how quickly a Github user's rate limit will be reached for the Github User API. Note: Github Enterprise does not have a rate limit!|`PT1M` (1 Minute)|
+
+This is what an example file would look like:
 ```properties
 github.api.url=https://github.example.com/api/v3 #note: no trailing slash!!!
+github.principal.cache.ttl=PT1M
 ```
-
-You can optionally provide the property `github.principal.cache.ttl` and set it
-to a java.time.Duration string to configure how long a given Github access
-token will be cached for. The default duration is 1 minute and is a tradeoff of
-how quickly access can be revoked and how quickly a Github user's rate limit
-will be reached for the Github User API.
 
 #### 5. Restart Nexus
 Restart your Nexus instance to let it pick up your changes.

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>gson</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
 </dependencies>
 
     <build>

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
@@ -9,6 +9,7 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Properties;
 
 @Singleton
@@ -21,6 +22,8 @@ public class GithubOauthConfiguration {
     private static final String GITHUB_ORGS_PATH = "/user/orgs";
 
     private static final String GITHUB_TEAMS_IN_ORG_PATH = "/teams";
+
+    private static final Duration DEFAULT_PRINCIPAL_CACHE_TTL = Duration.ofMinutes(1);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GithubOauthConfiguration.class);
 
@@ -52,5 +55,14 @@ public class GithubOauthConfiguration {
 
     public String getGithubUserUri() {
         return getGithubApiUrl() + GITHUB_USER_PATH;
+    }
+
+    public Duration getPrincipalCacheTtl() {
+        String override = configuration.getProperty("github.principal.cache.ttl");
+        if (override != null) {
+            return Duration.parse(override);
+        } else {
+            return DEFAULT_PRINCIPAL_CACHE_TTL;
+        }
     }
 }

--- a/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/MockGithubOauthConfiguration.java
+++ b/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/MockGithubOauthConfiguration.java
@@ -1,10 +1,22 @@
 package com.larscheidschmitzhermes.nexus3.github.oauth.plugin.configuration;
 
 
+import java.time.Duration;
+
 public class MockGithubOauthConfiguration extends GithubOauthConfiguration {
+    private Duration principalCacheTtl;
+
+    public MockGithubOauthConfiguration(Duration principalCacheTtl) {
+        this.principalCacheTtl = principalCacheTtl;
+    }
+
     @Override
     public String getGithubApiUrl() {
         return "http://github.example.com/api/v3";
     }
 
+    @Override
+    public Duration getPrincipalCacheTtl() {
+        return principalCacheTtl;
+    }
 }


### PR DESCRIPTION
By default, authorization checks will be cached for 1 minute. This will reduce
the load on Github APIs and help reduce the likelihood a user will be rate
limited. The README has instructions on how to override this default.