### PR TITLE
Use Github Username instead of Github Name for Principle's Username value

### DIFF
--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -81,9 +81,10 @@ public class GithubApiClient {
     }
 
     private GithubPrincipal doAuthz(String loginName, char[] token) throws GithubAuthenticationException {
-        GithubPrincipal principal = new GithubPrincipal();
+    	GithubUser githubUser = retrieveGithubUser(loginName, token);
+    	GithubPrincipal principal = new GithubPrincipal();
 
-        principal.setUsername(loginName);
+        principal.setUsername(githubUser.getLogin());
         principal.setRoles(generateRolesFromGithubOrgMemberships(token));
 
         return principal;

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -81,7 +81,6 @@ public class GithubApiClient {
     }
 
     private GithubPrincipal doAuthz(String loginName, char[] token) throws GithubAuthenticationException {
-        GithubUser githubUser = retrieveGithubUser(loginName, token);
         GithubPrincipal principal = new GithubPrincipal();
 
         principal.setUsername(loginName);

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -81,8 +81,8 @@ public class GithubApiClient {
     }
 
     private GithubPrincipal doAuthz(String loginName, char[] token) throws GithubAuthenticationException {
-    	GithubUser githubUser = retrieveGithubUser(loginName, token);
-    	GithubPrincipal principal = new GithubPrincipal();
+        GithubUser githubUser = retrieveGithubUser(loginName, token);
+        GithubPrincipal principal = new GithubPrincipal();
 
         principal.setUsername(githubUser.getLogin());
         principal.setRoles(generateRolesFromGithubOrgMemberships(token));

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -84,7 +84,7 @@ public class GithubApiClient {
         GithubUser githubUser = retrieveGithubUser(loginName, token);
         GithubPrincipal principal = new GithubPrincipal();
 
-        principal.setUsername(githubUser.getName() != null ? githubUser.getName() : loginName);
+        principal.setUsername(loginName);
         principal.setRoles(generateRolesFromGithubOrgMemberships(token));
 
         return principal;

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
@@ -2,8 +2,6 @@ package com.larscheidschmitzhermes.nexus3.github.oauth.plugin.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import java.util.List;
-
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GithubUser {
     private String name;

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GithubUser {
-    private List<GithubTeam> teams;
     private String name;
     private String login;
 

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
@@ -2,8 +2,11 @@ package com.larscheidschmitzhermes.nexus3.github.oauth.plugin.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.List;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GithubUser {
+	private List<GithubTeam> teams;
     private String name;
     private String login;
 

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubUser.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GithubUser {
-	private List<GithubTeam> teams;
+    private List<GithubTeam> teams;
     private String name;
     private String login;
 

--- a/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubApiClientTest.java
+++ b/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubApiClientTest.java
@@ -138,7 +138,6 @@ public class GithubApiClientTest {
         clientToTest.authz("demo-user", "DUMMY".toCharArray());
     }
 
-
     @Test
     public void cachedPrincipalReturnsIfNotExpired() throws Exception {
         HttpClient mockClient = fullyFunctionalMockClient();

--- a/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubApiClientTest.java
+++ b/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubApiClientTest.java
@@ -113,7 +113,7 @@ public class GithubApiClientTest {
 
         MatcherAssert.assertThat(authorizedPrincipal.getRoles().size(), Is.is(1));
         MatcherAssert.assertThat(authorizedPrincipal.getRoles().iterator().next(), Is.is("TEST-ORG/admin"));
-        MatcherAssert.assertThat(authorizedPrincipal.getUsername(), Is.is("Hans Wurst"));
+        MatcherAssert.assertThat(authorizedPrincipal.getUsername(), Is.is("demo-user"));
 
     }
 
@@ -127,19 +127,6 @@ public class GithubApiClientTest {
         GithubApiClient clientToTest = new GithubApiClient(mockClient, new MockGithubOauthConfiguration(Duration.ofDays(1)));
 
         clientToTest.authz("demo-user", "DUMMY".toCharArray());
-    }
-
-
-    @Test()
-    public void shouldFallbackToLoginNameIfUsernameNotSetInGit() throws Exception {
-        HttpClient mockClient = mockClientWithNullUsername();
-
-        GithubApiClient clientToTest = new GithubApiClient(mockClient, config);
-        GithubPrincipal authorizedPrincipal = clientToTest.authz("demo-user", "DUMMY".toCharArray());
-
-        MatcherAssert.assertThat(authorizedPrincipal.getRoles().size(), Is.is(1));
-        MatcherAssert.assertThat(authorizedPrincipal.getRoles().iterator().next(), Is.is("TEST-ORG/admin"));
-        MatcherAssert.assertThat(authorizedPrincipal.getUsername(), Is.is("demo-user"));
     }
 
     @Test(expected = GithubAuthenticationException.class)

--- a/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubApiClientTest.java
+++ b/src/test/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubApiClientTest.java
@@ -82,13 +82,6 @@ public class GithubApiClientTest {
         Mockito.when(mockClient.execute(Mockito.any())).thenAnswer(invocationOnMock -> answerOnInvocation(invocationOnMock, mockUserResponse));
     }
 
-    private HttpClient mockClientWithNullUsername() throws IOException {
-        HttpClient mockClient = Mockito.mock(HttpClient.class);
-        HttpResponse mockUserResponse = createMockResponse(mockUser(null));
-        Mockito.when(mockClient.execute(Mockito.any())).thenAnswer(invocationOnMock -> answerOnInvocation(invocationOnMock, mockUserResponse));
-        return mockClient;
-    }
-
     private HttpResponse answerOnInvocation(InvocationOnMock invocationOnMock, HttpResponse mockUserResponse) throws IOException {
         HttpResponse mockTeamResponse = createMockResponse(mockTeams());
         HttpResponse mockOrgsResponse = createMockResponse(mockOrg("TEST-ORG"));


### PR DESCRIPTION
Currently the plugin grabs the Github user's real name for populating the Principle's username value instead of the Github username - this should be avoided as when Nexus 3 prompts for authentication after the normal user login flow it will pre-populate the dialog with the Principle username in a disabled state thus github authentication will fail as the Principle username does not match the Github username.  