### PR TITLE
make principal serializable

### DIFF
--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubPrincipal.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubPrincipal.java
@@ -1,8 +1,9 @@
 package com.larscheidschmitzhermes.nexus3.github.oauth.plugin;
 
+import java.io.Serializable;
 import java.util.Set;
 
-public class GithubPrincipal {
+public class GithubPrincipal implements Serializable {
     private String username;
     private char[] oauthToken;
     private Set<String> roles;


### PR DESCRIPTION
when logging in with npm, we sometimes see errors like `Caused by: java.io.NotSerializableException: com.larscheidschmitzhermes.nexus3.github.oauth.plugin.GithubPrincipal`