### PR TITLE
Replace @PostConstruct directives with constructors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.2 as builder
+FROM maven:3 as builder
 MAINTAINER matt.brewster@base2s.com
 COPY . /build
 WORKDIR /build
 RUN mvn versions:set -DnewVersion=docker; mvn clean package
 
-FROM sonatype/nexus3:3.11.0
+FROM sonatype/nexus3:3.16.1
 USER root
 RUN mkdir -p /opt/sonatype/nexus/system/com/larscheidschmitzhermes/nexus3-github-oauth-plugin/docker/
 COPY --from=builder /build/target/nexus3-github-oauth-plugin-docker.jar /opt/sonatype/nexus/system/com/larscheidschmitzhermes/nexus3-github-oauth-plugin/docker/

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -38,6 +38,7 @@ public class GithubApiClient {
 
     public GithubApiClient() {
         //no args constructor is needed
+        init()
     }
 
     public GithubApiClient(HttpClient client, GithubOauthConfiguration configuration) {
@@ -50,9 +51,9 @@ public class GithubApiClient {
     @Inject
     public GithubApiClient(GithubOauthConfiguration configuration) {
         this.configuration = configuration;
+        init();
     }
 
-    @PostConstruct
     public void init() {
         client = HttpClientBuilder.create().build();
         mapper = new ObjectMapper();

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
@@ -39,8 +39,7 @@ public class GithubOauthConfiguration {
 
     private Properties configuration;
 
-    @PostConstruct
-    public void init() {
+    public GithubOauthConfiguration() {
         configuration = new Properties();
 
         try {


### PR DESCRIPTION
Why:
  * PostConstruct is depricated
  * This broke the plugin

Also:
  * Updated mvn tag used
  * Updated docker to build with newer version