### PR TITLE
Lock build to JDK8 so it still builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3 as builder
+FROM maven:3-jdk-8 as builder
 MAINTAINER matt.brewster@base2s.com
 COPY . /build
 WORKDIR /build


### PR DESCRIPTION
Project doesn't build under JDK11 which is the new default for `maven:3`