### PR TITLE
Make http client timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Within the file you can configure the following properties:
 |`github.api.url`|URL of the Github API to operate against.|`https://api.github.com`|
 |`github.principal.cache.ttl`|[Java Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) for how long a given Access will be cached for. This is a tradeoff of how quickly access can be revoked and how quickly a Github user's rate limit will be reached for the Github User API. _Note:_ Github Enterprise does not have a rate limit!|`PT1M` (1 Minute)|
 |`github.org`|The Organization the user should be a member of. If this is not set anyone with a Github account is allowed tot login.|----|
+|`request.timeout.connection-request`|The timeout in milliseconds used when requesting a connection from the connection manager. A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default).|`-1`|
+|`request.timeout.connect`|The timeout in milliseconds until a connection is established. A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default).|`-1`|
+|`request.timeout.socket`|The socket timeout (`SO_TIMEOUT`) in milliseconds, which is the timeout for waiting for data  or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. A negative value is interpreted as undefined (system default).|`-1`|
 
 This is what an example file would look like:
 ```properties

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -12,6 +12,7 @@ import javax.inject.Singleton;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
@@ -55,7 +56,15 @@ public class GithubApiClient {
     }
 
     public void init() {
-        client = HttpClientBuilder.create().build();
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(configuration.getRequestConnectTimeout())
+                .setConnectionRequestTimeout(configuration.getRequestConnectionRequestTimeout())
+                .setSocketTimeout(configuration.getRequestSocketTimeout())
+                .build();
+        client = HttpClientBuilder
+                .create()
+                .setDefaultRequestConfig(config)
+                .build();
         mapper = new ObjectMapper();
         initPrincipalCache();
     }

--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
@@ -35,6 +35,18 @@ public class GithubOauthConfiguration {
 
     private static final String GITHUB_ORG = "github.org";
 
+    private static final String REQUEST_CONNECT_TIMEOUT = "request.timeout.connect";
+
+    private static final int DEFAULT_REQUEST_CONNECT_TIMEOUT = -1;
+
+    private static final String REQUEST_CONNECTION_REQUEST_TIMEOUT = "request.timeout.connection-request";
+
+    private static final int DEFAULT_REQUEST_CONNECTION_REQUEST_TIMEOUT = -1;
+
+    private static final String REQUEST_SOCKET_TIMEOUT = "request.timeout.socket";
+
+    private static final int DEFAULT_REQUEST_SOCKET_TIMEOUT = -1;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(GithubOauthConfiguration.class);
 
     private Properties configuration;
@@ -68,5 +80,17 @@ public class GithubOauthConfiguration {
 
     public Duration getPrincipalCacheTtl() {
         return Duration.parse(configuration.getProperty(GITHUB_PRINCIPAL_CACHE_TTL_KEY, DEFAULT_PRINCIPAL_CACHE_TTL.toString()));
+    }
+
+    public int getRequestConnectTimeout() {
+        return Integer.parseInt(configuration.getProperty(REQUEST_CONNECT_TIMEOUT, String.valueOf(DEFAULT_REQUEST_CONNECT_TIMEOUT)));
+    }
+
+    public Integer getRequestConnectionRequestTimeout() {
+        return Integer.parseInt(configuration.getProperty(REQUEST_CONNECTION_REQUEST_TIMEOUT, String.valueOf(DEFAULT_REQUEST_CONNECTION_REQUEST_TIMEOUT)));
+    }
+
+    public Integer getRequestSocketTimeout() {
+        return Integer.parseInt(configuration.getProperty(REQUEST_SOCKET_TIMEOUT, String.valueOf(DEFAULT_REQUEST_SOCKET_TIMEOUT)));
     }
 }


### PR DESCRIPTION
Under load, we sometimes get broken connections to the GitHub API that leads to leaked connections in the client connection pool due to a not specified timeout. This PR makes the connection timeouts configurable.