### PR TITLE
Please use a delimiter between org/team names

### DIFF
--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubOauthAuthenticatingRealm.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/GithubOauthAuthenticatingRealm.java
@@ -76,7 +76,7 @@ public class GithubOauthAuthenticatingRealm extends AuthorizingRealm {
 	@Override
 	protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
 		GithubPrincipal user = (GithubPrincipal) principals.getPrimaryPrincipal();
-		LOGGER.info("doGetAuthorizationInfo for user {} with roles {}", user.getUsername(), user.getRoles().stream().collect(Collectors.joining()));
+		LOGGER.info("doGetAuthorizationInfo for user {} with roles {}", user.getUsername(), user.getRoles().stream().collect(Collectors.joining(", ")));
 		return new SimpleAuthorizationInfo(user.getRoles());
 	}
 


### PR DESCRIPTION
Please use a delimiter between org/team names in the log.

Expected:
Log messages will not be hard to distinguish due to org/team names not being represented as discreet units.

Actual:
Org/team names are combined into a single string which must be manually separated.

Reproducing:
Log into nexus via Github oauth using an account with multiple teams in an organization (e.g org1/team1 and org1/team2). Observe that in the log the organization and team names are combined (e.g. org1/team1org1/team2).